### PR TITLE
Allow inspection of in-memory HSQLDB, closes #168

### DIFF
--- a/service/src/main/java/org/coner/core/dagger/ConerModule.java
+++ b/service/src/main/java/org/coner/core/dagger/ConerModule.java
@@ -2,6 +2,8 @@ package org.coner.core.dagger;
 
 import javax.inject.Singleton;
 
+import org.coner.core.ConerCoreConfiguration;
+import org.coner.core.task.HsqlDatabaseManagerSwingTask;
 import org.hibernate.SessionFactory;
 
 import dagger.Module;
@@ -10,9 +12,11 @@ import dagger.Provides;
 @Module
 public class ConerModule {
 
+    private final ConerCoreConfiguration configuration;
     private final SessionFactory sessionFactory;
 
-    public ConerModule(SessionFactory sessionFactory) {
+    public ConerModule(ConerCoreConfiguration configuration, SessionFactory sessionFactory) {
+        this.configuration = configuration;
         this.sessionFactory = sessionFactory;
     }
 
@@ -20,6 +24,12 @@ public class ConerModule {
     @Singleton
     public SessionFactory getSessionFactory() {
         return sessionFactory;
+    }
+
+    @Provides
+    @Singleton
+    public HsqlDatabaseManagerSwingTask getHsqlDatabaseManagerSwingTask(SessionFactory sessionFactory) {
+        return new HsqlDatabaseManagerSwingTask(configuration.getDataSourceFactory().getUrl());
     }
 
 }

--- a/service/src/main/java/org/coner/core/dagger/JerseyRegistrationComponent.java
+++ b/service/src/main/java/org/coner/core/dagger/JerseyRegistrationComponent.java
@@ -9,6 +9,7 @@ import org.coner.core.resource.EventRegistrationsResource;
 import org.coner.core.resource.EventsResource;
 import org.coner.core.resource.HandicapGroupSetsResource;
 import org.coner.core.resource.HandicapGroupsResource;
+import org.coner.core.task.HsqlDatabaseManagerSwingTask;
 
 import dagger.Component;
 
@@ -25,4 +26,7 @@ public interface JerseyRegistrationComponent {
 
     // Exception Mappers
     DomainServiceExceptionMapper domainServiceExceptionMapper();
+
+    // Tasks
+    HsqlDatabaseManagerSwingTask hsqlDatabaseManagerSwingTask();
 }

--- a/service/src/main/java/org/coner/core/task/HsqlDatabaseManagerSwingTask.java
+++ b/service/src/main/java/org/coner/core/task/HsqlDatabaseManagerSwingTask.java
@@ -1,0 +1,39 @@
+package org.coner.core.task;
+
+import java.io.PrintWriter;
+import java.util.Map;
+
+import org.hsqldb.util.DatabaseManagerSwing;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+public class HsqlDatabaseManagerSwingTask extends Task {
+
+    private final String url;
+    private String[] args;
+    boolean ok = false;
+    Runnable execution = () -> DatabaseManagerSwing.main(args);
+
+    public HsqlDatabaseManagerSwingTask(String url) {
+        super(DatabaseManagerSwing.class.getCanonicalName());
+        this.url = url;
+        this.args = new String[]{"--url", url, "--noexit"};
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+        Preconditions.checkState(ok, "Registered without calling shouldRegister() or when returned false");
+        execution.run();
+    }
+
+    public boolean shouldRegister(Map<String, String> properties) {
+        String propertyName = HsqlDatabaseManagerSwingTask.class.getCanonicalName();
+        ok = url.contains(":hsqldb:")
+                && properties.containsKey(propertyName)
+                && "true".equals(properties.get(propertyName));
+        return ok;
+    }
+
+}

--- a/service/src/main/java/org/coner/core/task/HsqlDatabaseManagerSwingTask.java
+++ b/service/src/main/java/org/coner/core/task/HsqlDatabaseManagerSwingTask.java
@@ -30,7 +30,7 @@ public class HsqlDatabaseManagerSwingTask extends Task {
 
     public boolean shouldRegister(Map<String, String> properties) {
         String propertyName = HsqlDatabaseManagerSwingTask.class.getCanonicalName();
-        ok = url.contains(":hsqldb:")
+        ok = url.contains(":hsqldb:mem:")
                 && properties.containsKey(propertyName)
                 && "true".equals(properties.get(propertyName));
         return ok;

--- a/service/src/test/java/org/coner/core/dagger/MockitoJerseyRegistrationModule.java
+++ b/service/src/test/java/org/coner/core/dagger/MockitoJerseyRegistrationModule.java
@@ -9,6 +9,7 @@ import org.coner.core.resource.EventRegistrationsResource;
 import org.coner.core.resource.EventsResource;
 import org.coner.core.resource.HandicapGroupSetsResource;
 import org.coner.core.resource.HandicapGroupsResource;
+import org.coner.core.task.HsqlDatabaseManagerSwingTask;
 import org.mockito.Mockito;
 
 import dagger.Module;
@@ -57,5 +58,11 @@ public class MockitoJerseyRegistrationModule {
     @Singleton
     public DomainServiceExceptionMapper getDomainServiceExceptionMapper() {
         return Mockito.mock(DomainServiceExceptionMapper.class);
+    }
+
+    @Provides
+    @Singleton
+    public HsqlDatabaseManagerSwingTask getHsqlDatabaseManagerSwingTask() {
+        return Mockito.mock(HsqlDatabaseManagerSwingTask.class);
     }
 }

--- a/service/src/test/java/org/coner/core/task/HsqlDatabaseManagerSwingTaskTest.java
+++ b/service/src/test/java/org/coner/core/task/HsqlDatabaseManagerSwingTaskTest.java
@@ -1,0 +1,76 @@
+package org.coner.core.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+
+public class HsqlDatabaseManagerSwingTaskTest {
+
+    private static final String URL_HSQLDB = "jdbc:hsqldb:mem:coner";
+    private static final String URL_NON_HSQLDB = "jdbc:sqlite::memory";
+    private final Map<String, String> properties = new HashMap<>();
+
+    private HsqlDatabaseManagerSwingTask task;
+
+    @Before
+    public void setup() {
+        properties.clear();
+    }
+
+    @Test
+    public void whenShouldRegisterWithEverythingRequired() {
+        task = new HsqlDatabaseManagerSwingTask(URL_HSQLDB);
+        properties.put(HsqlDatabaseManagerSwingTask.class.getCanonicalName(), Boolean.TRUE.toString());
+
+        boolean actual = task.shouldRegister(properties);
+
+        assertThat(actual).isTrue().isEqualTo(task.ok);
+    }
+
+    @Test
+    public void whenShouldRegisterWithoutHsqldbUrl() {
+        task = new HsqlDatabaseManagerSwingTask(URL_NON_HSQLDB);
+        properties.put(HsqlDatabaseManagerSwingTask.class.getCanonicalName(), Boolean.TRUE.toString());
+
+        boolean actual = task.shouldRegister(properties);
+
+        assertThat(actual).isFalse().isEqualTo(task.ok);
+    }
+
+    @Test
+    public void whenExecuteValidItShouldRunExecution() throws Exception {
+        task = new HsqlDatabaseManagerSwingTask(URL_HSQLDB);
+        task.execution = mock(Runnable.class);
+        task.ok = true;
+
+        task.execute(mock(ImmutableMultimap.class), mock(PrintWriter.class));
+
+        verify(task.execution).run();
+    }
+
+    @Test
+    public void whenExecuteInvalidItShouldThrow() throws Exception {
+        task = new HsqlDatabaseManagerSwingTask(URL_HSQLDB);
+        task.execution = mock(Runnable.class);
+        task.ok = false;
+
+        try {
+            task.execute(mock(ImmutableMultimap.class), mock(PrintWriter.class));
+            failBecauseExceptionWasNotThrown(IllegalStateException.class);
+        } catch (IllegalStateException e) {
+            verify(task.execution, never()).run();
+        }
+    }
+
+}

--- a/service/src/test/resources/config/test.yml
+++ b/service/src/test/resources/config/test.yml
@@ -12,6 +12,7 @@ database:
     properties:
         hibernate.dialect: org.hibernate.dialect.HSQLDialect
         hibernate.hbm2ddl.auto: create
+        org.coner.core.task.HsqlDatabaseManagerSwingTask: false
 
 # Swagger settings
 swagger:


### PR DESCRIPTION
To enable, start service with a config file containing the below settings:

database.url: Contains `:hsqldb:mem:`
database.properties.org.coner.core.task.HsqlDatabaseManagerSwingTask: true

To start the HSQL DatabaseManagerSwing, `POST http://localhost:8081/tasks/org.hsqldb.util.DatabaseManagerSwing`

If the above mentioned settings **are** set correctly, the POST will respond with HTTP status 200, and `org.hsqldb.util.DatabaseManagerSwing` will appear on the display of the service's host.

If the above mentioned settings **are not** set correctly, the POST will respond with HTTP status 404, and no further action will be taken.